### PR TITLE
Date format selector

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -354,5 +354,18 @@ class LetterboxdSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings()
 				})
 			})
+
+		new Setting(containerEl)
+			.setName('Date Format')
+			.setDesc('Enter the Moment.js date format to display watched dates (e.g., YYYY-MM-DD)')
+			.addText((component) => {
+				component.setPlaceholder('YYYY-MM-DD');
+				component.setValue(this.plugin.settings.dateFormat);
+				component.onChange(async (value) => {
+					this.plugin.settings.dateFormat = value;
+					await this.plugin.saveSettings();
+				});
+			});
+		
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -354,18 +354,35 @@ class LetterboxdSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings()
 				})
 			})
-
-		new Setting(containerEl)
-			.setName('Date Format')
-			.setDesc('Enter the Moment.js date format to display watched dates (e.g., YYYY-MM-DD)')
-			.addText((component) => {
-				component.setPlaceholder('YYYY-MM-DD');
-				component.setValue(this.plugin.settings.dateFormat);
-				component.onChange(async (value) => {
-					this.plugin.settings.dateFormat = value;
-					await this.plugin.saveSettings();
-				});
-			});
 		
+			let datePreviewSpan: HTMLElement;
+
+const dateFormatSetting = new Setting(containerEl)
+	.setName('Date Format')
+	.setDesc('Enter the Moment.js date format to display watched dates (e.g., YYYY-MM-DD)');
+
+dateFormatSetting.addText((text) => {
+	text.setPlaceholder('YYYY-MM-DD');
+	text.setValue(this.plugin.settings.dateFormat);
+	text.onChange(async (value) => {
+		this.plugin.settings.dateFormat = value;
+		await this.plugin.saveSettings();
+		try {
+			datePreviewSpan.textContent = moment().format(value);
+		} catch (error) {
+			datePreviewSpan.textContent = 'Invalid format';
+		}
+	});
+});
+
+// Append the preview element to the info element (left column) so it appears below the description.
+datePreviewSpan = dateFormatSetting.infoEl.createEl('div', { cls: 'date-format-preview' });
+datePreviewSpan.style.fontSize = '0.8em';    // Smaller font size
+datePreviewSpan.style.marginTop = '4px';       // Small margin for spacing
+datePreviewSpan.style.whiteSpace = 'nowrap';   // Keep it on one single line
+datePreviewSpan.style.color = 'var(--text-accent)';  // Obsidian’s accent (purple) color
+datePreviewSpan.textContent = `This is how it will look: ${moment().format(this.plugin.settings.dateFormat)}`;
+
+			
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, PluginSettingTab, Setting, requestUrl, FuzzySuggestModal, TAbstractFile, TFile, TextComponent, normalizePath, moment } from 'obsidian';
+import { App, Plugin, PluginSettingTab, Setting, requestUrl, FuzzySuggestModal, TAbstractFile, TFile, TextComponent, normalizePath, moment, Notice } from 'obsidian';
 import { XMLParser } from 'fast-xml-parser';
 import {
 	getDailyNoteSettings
@@ -13,6 +13,8 @@ interface LetterboxdSettings {
 	callout: 'List' | 'ListReview' | 'Callout' | 'CalloutPoster';
 	stars: number;
 	addReferenceId: boolean;
+	syncMovieNotes: boolean;
+	moviesPath: string;
 }
 
 /**
@@ -50,6 +52,38 @@ interface RSSEntry {
 	'tmdb:tvId': number
 	description: string
 	'dc:creator': string
+}
+
+interface ParsedEntry {
+	filmTitle: string;
+	link: string;
+	guid: string;
+	watchedDate: string;
+	filmYear?: number;
+	memberRating?: number;
+	posterUrl: string | null;
+	reviewText: string | null;
+}
+
+interface MovieEntry {
+	filmTitle: string;
+	link: string;
+	watchedDate: string;
+	filmYear?: number;
+	memberRating?: number;
+	rating100?: number;
+	posterUrl: string | null;
+	reviewText: string | null;
+}
+
+interface FilmMetadata {
+	genres: string[];
+	directors: string[];
+	cast: string[];
+	cover?: string;
+	plot?: string;
+	scoreLB?: number;
+	year?: number;
 }
 
 // FileSelect is a subclass of FuzzySuggestModal that is used to select a file from the vault
@@ -113,12 +147,97 @@ const DEFAULT_SETTINGS: LetterboxdSettings = {
 	callout: 'List',
 	stars: 0,
 	addReferenceId: false,
+	syncMovieNotes: true,
+	moviesPath: '06 - Resources/Movies',
 }
 
 const decodeHtmlEntities = (text: string) => {
 	const txt = document.createElement("textarea");
 	txt.innerHTML = text;
 	return txt.value;
+};
+
+const toHundredScale = (rating?: number): number | undefined => {
+	if (rating === undefined) return undefined;
+	return Math.round(rating * 20);
+};
+
+const sanitizeMovieFilename = (title: string): string => {
+	const cleanTitle = title.replace(/[\\/:*?"<>|]/g, '').replace(/\s+/g, ' ').trim();
+	return cleanTitle.length ? cleanTitle : 'Untitled Movie';
+};
+
+const ensureStringArray = (value: unknown): string[] => {
+	if (Array.isArray(value)) {
+		return value
+			.map((entry) => String(entry).trim())
+			.filter((entry) => entry.length > 0);
+	}
+	if (typeof value === 'string') {
+		return value
+			.split(',')
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0);
+	}
+	return [];
+};
+
+const hasValue = (value: unknown): boolean => {
+	if (value === undefined || value === null) return false;
+	if (typeof value === 'string') return value.trim().length > 0;
+	if (Array.isArray(value)) return value.length > 0;
+	return true;
+};
+
+const uniqueStrings = (values: string[]): string[] => Array.from(new Set(values.map((value) => decodeHtmlEntities(value).trim()).filter((value) => value.length > 0)));
+
+const toWikiLinks = (values: string[]): string[] => uniqueStrings(values).map((value) => `[[${value}]]`);
+
+const extractStringValues = (value: unknown): string[] => {
+	if (Array.isArray(value)) {
+		return uniqueStrings(value.flatMap((entry) => extractStringValues(entry)));
+	}
+	if (typeof value === 'string') {
+		return uniqueStrings([value]);
+	}
+	if (value && typeof value === 'object') {
+		const namedValue = (value as Record<string, unknown>).name;
+		if (typeof namedValue === 'string') return uniqueStrings([namedValue]);
+	}
+	return [];
+};
+
+const splitFrontmatter = (content: string): { frontmatter: string; body: string } => {
+	const match = content.match(/^---\n[\s\S]*?\n---\n?/);
+	if (!match) return { frontmatter: '', body: content };
+	return {
+		frontmatter: match[0].endsWith('\n') ? match[0] : `${match[0]}\n`,
+		body: content.slice(match[0].length),
+	};
+};
+
+const parseEntry = (item: RSSEntry): ParsedEntry => {
+	const description = document.createElement('div');
+	description.innerHTML = item.description ?? '';
+	const imgElement = description.querySelector('img');
+	const posterUrl = imgElement ? imgElement.src : null;
+	const reviewParts = Array.from(description.querySelectorAll('p'))
+		.map((p) => (p.textContent ?? '').trim())
+		.filter((text) => text.length > 0 && !/^Watched on\b/i.test(text));
+	const reviewText = reviewParts.length ? reviewParts.join('\n\n') : null;
+	const memberRating = typeof item['letterboxd:memberRating'] === 'number' ? item['letterboxd:memberRating'] : undefined;
+	const filmYear = typeof item['letterboxd:filmYear'] === 'number' ? item['letterboxd:filmYear'] : undefined;
+
+	return {
+		filmTitle: decodeHtmlEntities(item['letterboxd:filmTitle'] ?? item.title).trim(),
+		link: item.link,
+		guid: item.guid,
+		watchedDate: item['letterboxd:watchedDate'],
+		filmYear,
+		memberRating,
+		posterUrl,
+		reviewText,
+	};
 };
 
 const objToFrontmatter = (obj: Record<string, any>): string => {
@@ -148,16 +267,10 @@ function starParser(rating: number | undefined, star: number): string {
 }
 
 function printOut(settings: LetterboxdSettings, item: RSSEntry) {
-	let description = document.createElement('div');
-	description.innerHTML = item.description;
-	const imgElement = description.querySelector('img');
-	let img = imgElement ? imgElement.src : null;
-	let reviewText: string | null = Array.from(description.querySelectorAll('p'))
-		.map(p => p.textContent)
-		.filter(text => text && text.trim() !== "")
-		.join('\r > \r > ');
-	if (reviewText.contains('Watched on')) reviewText = null;
-	const filmTitle = decodeHtmlEntities(item['letterboxd:filmTitle']);
+	const parsed = parseEntry(item);
+	const img = parsed.posterUrl;
+	const reviewText = parsed.reviewText ? parsed.reviewText.split('\n').join('\r > \r > ') : null;
+	const filmTitle = parsed.filmTitle;
 	const watchedDate = settings.dateFormat
 		? moment(item['letterboxd:watchedDate']).format(settings.dateFormat)
 		: item['letterboxd:watchedDate'];
@@ -183,6 +296,7 @@ function printOut(settings: LetterboxdSettings, item: RSSEntry) {
 
 export default class LetterboxdPlugin extends Plugin {
 	settings: LetterboxdSettings;
+	private filmMetadataCache = new Map<string, FilmMetadata>();
 
 	async onload() {
 		await this.loadSettings();
@@ -194,58 +308,339 @@ export default class LetterboxdPlugin extends Plugin {
 				if (!this.settings.username) {
 					throw new Error('Cannot get data for blank username')
 				}
-				requestUrl(`https://letterboxd.com/${this.settings.username}/rss/`)
-					.then(res => res.text)
-					.then(async res => {
-						const parser = new XMLParser();
-						let jObj = parser.parse(res);
-						const filename = normalizePath(this.settings.path.endsWith('.md') ? this.settings.path : this.settings.path + '.md');
-						const diaryMdArr = (jObj.rss.channel.item as RSSEntry[])
-							.sort((a, b) => {
-								const dateA = new Date(a.pubDate).getTime();
-								const dateB = new Date(b.pubDate).getTime();
-								return this.settings.sort === 'Old' ? dateA - dateB : dateB - dateA;
-							})
-							.map((item: RSSEntry) => {
-								return printOut(this.settings, item);
-							})
-						const diaryFile = this.app.vault.getFileByPath(filename)
-						if (diaryFile === null) {
-							let pathArray = this.settings.path.split('/');
-							pathArray.pop();
-							if (pathArray.length > 1) this.app.vault.createFolder(pathArray.join('/'));
-							this.app.vault.create(filename, `${diaryMdArr.join('\n')}`);
-						} else {
-							let frontMatter = '';
-							this.app.fileManager.processFrontMatter(diaryFile, (data) => {
-								if (Object.keys(data).length) frontMatter = objToFrontmatter(data);
-							});
-							this.app.vault.process(diaryFile, (data) => {
-								let diaryContentsArr = data.split('\n');
-								// If there is frontmatter, this works out how many lines to ignore.
-								if (frontMatter.length) {
-									let count = 0;
-									while (diaryContentsArr.length > 0) {
-										let firstElement = diaryContentsArr.shift();
-										if (firstElement === '---') {
-											count++;
-											if (count === 2) break;
-										}
-									}
-								}
-								const diaryContentsSet = new Set(diaryContentsArr);
-								const newEntries = diaryMdArr.filter((entry: string) => !diaryContentsSet.has(entry));
-								const finalEntries = this.settings.sort === 'Old'
-									? [...diaryContentsArr, ...newEntries]
-									: [...newEntries, ...diaryContentsArr];
-								return frontMatter.length ? frontMatter + finalEntries.join('\n') : finalEntries.join('\n');
-							})
-						}
-					})
+				try {
+					const response = await requestUrl(`https://letterboxd.com/${this.settings.username}/rss/`);
+					const parser = new XMLParser();
+					const parsedRss = parser.parse(response.text);
+					const rssItems = parsedRss?.rss?.channel?.item;
+					const diaryEntries = (Array.isArray(rssItems) ? rssItems : rssItems ? [rssItems] : []) as RSSEntry[];
+					const sortedEntries = diaryEntries.sort((a, b) => {
+						const dateA = new Date(a.pubDate).getTime();
+						const dateB = new Date(b.pubDate).getTime();
+						return this.settings.sort === 'Old' ? dateA - dateB : dateB - dateA;
+					});
+					const newDiaryEntries = await this.syncDiaryNote(sortedEntries);
+					const movieNotesProcessed = await this.syncMovieNotes(sortedEntries);
+					new Notice(`Letterboxd sync: ${newDiaryEntries} nuevas entradas en diario, ${movieNotesProcessed} peliculas procesadas.`);
+				} catch (error) {
+					console.error('Letterboxd sync failed', error);
+					new Notice(`Letterboxd sync fallo: ${error instanceof Error ? error.message : 'error desconocido'}`);
+				}
 			},
 		})
 
 		this.addSettingTab(new LetterboxdSettingTab(this.app, this));
+	}
+
+	private async syncDiaryNote(entries: RSSEntry[]): Promise<number> {
+		const filename = normalizePath(this.settings.path.endsWith('.md') ? this.settings.path : `${this.settings.path}.md`);
+		const diaryMdArr = entries.map((item) => printOut(this.settings, item));
+		const diaryFile = this.app.vault.getFileByPath(filename);
+
+		if (diaryFile === null) {
+			const pathArray = this.settings.path.split('/');
+			pathArray.pop();
+			if (pathArray.length > 1) {
+				await this.ensureFolderExists(pathArray.join('/'));
+			}
+			await this.app.vault.create(filename, diaryMdArr.join('\n'));
+			return diaryMdArr.length;
+		}
+
+		let frontMatter = '';
+		await this.app.fileManager.processFrontMatter(diaryFile, (data) => {
+			if (Object.keys(data).length) frontMatter = objToFrontmatter(data);
+		});
+
+		let newEntriesCount = 0;
+		await this.app.vault.process(diaryFile, (data) => {
+			const diaryContentsArr = data.split('\n');
+			if (frontMatter.length) {
+				let count = 0;
+				while (diaryContentsArr.length > 0) {
+					const firstElement = diaryContentsArr.shift();
+					if (firstElement === '---') {
+						count++;
+						if (count === 2) break;
+					}
+				}
+			}
+			const diaryContentsSet = new Set(diaryContentsArr);
+			const newEntries = diaryMdArr.filter((entry: string) => !diaryContentsSet.has(entry));
+			newEntriesCount = newEntries.length;
+			const finalEntries = this.settings.sort === 'Old'
+				? [...diaryContentsArr, ...newEntries]
+				: [...newEntries, ...diaryContentsArr];
+			return frontMatter.length ? frontMatter + finalEntries.join('\n') : finalEntries.join('\n');
+		});
+		return newEntriesCount;
+	}
+
+	private async syncMovieNotes(entries: RSSEntry[]): Promise<number> {
+		if (!this.settings.syncMovieNotes) return 0;
+		await this.ensureFolderExists(this.settings.moviesPath);
+		const movieMap = this.groupEntriesByMovie(entries);
+		for (const movieEntry of movieMap.values()) {
+			await this.upsertMovieNote(movieEntry);
+		}
+		return movieMap.size;
+	}
+
+	private getFilmPageUrl(entryLink: string): string | null {
+		try {
+			const url = new URL(entryLink);
+			const pathParts = url.pathname.split('/').filter(Boolean);
+			const filmIndex = pathParts.findIndex((part) => part === 'film');
+			if (filmIndex < 0 || !pathParts[filmIndex + 1]) return null;
+			return `${url.origin}/film/${pathParts[filmIndex + 1]}/`;
+		} catch {
+			return null;
+		}
+	}
+
+	private findMovieSchema(data: unknown): Record<string, unknown> | null {
+		if (Array.isArray(data)) {
+			for (const entry of data) {
+				const found = this.findMovieSchema(entry);
+				if (found) return found;
+			}
+			return null;
+		}
+		if (!data || typeof data !== 'object') return null;
+		const record = data as Record<string, unknown>;
+		const typeValue = record['@type'];
+		const isMovieType = (typeof typeValue === 'string' && typeValue.toLowerCase() === 'movie')
+			|| (Array.isArray(typeValue) && typeValue.some((type) => typeof type === 'string' && type.toLowerCase() === 'movie'));
+		if (isMovieType) return record;
+		for (const value of Object.values(record)) {
+			const found = this.findMovieSchema(value);
+			if (found) return found;
+		}
+		return null;
+	}
+
+	private parseFilmMetadataFromHtml(html: string): FilmMetadata | null {
+		const parser = new DOMParser();
+		const htmlDoc = parser.parseFromString(html, 'text/html');
+		let ldJsonScripts = Array.from(htmlDoc.querySelectorAll('script[type="application/ld+json"]'));
+		if (!ldJsonScripts.length) {
+			// Fallback for edge cases where scripts are not exposed in the parsed DOM.
+			const ldJsonMatches = html.match(/<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi) ?? [];
+			ldJsonScripts = ldJsonMatches.map((rawScript) => {
+				const scriptEl = document.createElement('script');
+				const contentMatch = rawScript.match(/<script[^>]*>([\s\S]*?)<\/script>/i);
+				scriptEl.textContent = contentMatch?.[1] ?? '';
+				return scriptEl;
+			});
+		}
+		let movieSchema: Record<string, unknown> | null = null;
+
+		for (const script of ldJsonScripts) {
+			const rawJson = script.textContent?.trim();
+			if (!rawJson) continue;
+			try {
+				const cleanedJson = rawJson
+					.replace(/^\/\*\s*<!\[CDATA\[\s*\*\/\s*/i, '')
+					.replace(/\s*\/\*\s*\]\]>\s*\*\/$/i, '')
+					.trim();
+				const parsedJson = JSON.parse(cleanedJson) as unknown;
+				const foundSchema = this.findMovieSchema(parsedJson);
+				if (foundSchema) {
+					movieSchema = foundSchema;
+					break;
+				}
+			} catch {
+				continue;
+			}
+		}
+
+		if (!movieSchema) return null;
+
+		const releasedEvent = movieSchema.releasedEvent;
+		let year: number | undefined;
+		if (Array.isArray(releasedEvent) && releasedEvent.length > 0) {
+			const startDate = (releasedEvent[0] as Record<string, unknown>)?.startDate;
+			if (typeof startDate === 'string') {
+				const yearMatch = startDate.match(/\d{4}/);
+				if (yearMatch) year = parseInt(yearMatch[0], 10);
+			}
+		}
+		if (!year && typeof movieSchema.dateCreated === 'string') {
+			const yearMatch = movieSchema.dateCreated.match(/\d{4}/);
+			if (yearMatch) year = parseInt(yearMatch[0], 10);
+		}
+
+		const aggregateRating = movieSchema.aggregateRating as Record<string, unknown> | undefined;
+		let scoreLB: number | undefined;
+		if (aggregateRating) {
+			const ratingValue = aggregateRating.ratingValue;
+			if (typeof ratingValue === 'number') scoreLB = ratingValue;
+			if (typeof ratingValue === 'string') {
+				const parsedRating = Number.parseFloat(ratingValue);
+				if (!Number.isNaN(parsedRating)) scoreLB = parsedRating;
+			}
+		}
+
+		let plot = '';
+		const metaDescription = htmlDoc.querySelector('meta[name="description"]')?.getAttribute('content')
+			|| htmlDoc.querySelector('meta[property="og:description"]')?.getAttribute('content');
+		if (metaDescription) plot = decodeHtmlEntities(metaDescription).trim();
+		if (!plot && typeof movieSchema.description === 'string') plot = decodeHtmlEntities(movieSchema.description).trim();
+
+		const cover = typeof movieSchema.image === 'string' ? movieSchema.image : undefined;
+
+		return {
+			genres: extractStringValues(movieSchema.genre),
+			directors: extractStringValues(movieSchema.director),
+			cast: extractStringValues(movieSchema.actors).slice(0, 5),
+			cover,
+			plot: plot.length ? plot : undefined,
+			scoreLB,
+			year,
+		};
+	}
+
+	private async fetchFilmMetadata(entryLink: string): Promise<FilmMetadata | null> {
+		const filmUrl = this.getFilmPageUrl(entryLink);
+		if (!filmUrl) return null;
+
+		const cachedMetadata = this.filmMetadataCache.get(filmUrl);
+		if (cachedMetadata !== undefined) return cachedMetadata;
+
+		try {
+			const response = await requestUrl(filmUrl);
+			const parsedMetadata = this.parseFilmMetadataFromHtml(response.text);
+			if (parsedMetadata) this.filmMetadataCache.set(filmUrl, parsedMetadata);
+			return parsedMetadata;
+		} catch (error) {
+			console.warn(`Letterboxd metadata fetch failed for ${filmUrl}`, error);
+			return null;
+		}
+	}
+
+	private groupEntriesByMovie(entries: RSSEntry[]): Map<string, MovieEntry> {
+		const movieMap = new Map<string, MovieEntry>();
+
+		for (const item of entries) {
+			const parsed = parseEntry(item);
+			if (!parsed.filmTitle.length) continue;
+			const key = (parsed.link || parsed.filmTitle).replace(/\/+$/, '').toLowerCase();
+			const existing = movieMap.get(key);
+			const candidate: MovieEntry = {
+				filmTitle: parsed.filmTitle,
+				link: parsed.link,
+				watchedDate: parsed.watchedDate,
+				filmYear: parsed.filmYear,
+				memberRating: parsed.memberRating,
+				rating100: toHundredScale(parsed.memberRating),
+				posterUrl: parsed.posterUrl,
+				reviewText: parsed.reviewText,
+			};
+
+			if (!existing) {
+				movieMap.set(key, candidate);
+				continue;
+			}
+
+			if (candidate.watchedDate > existing.watchedDate) {
+				existing.watchedDate = candidate.watchedDate;
+				existing.link = candidate.link || existing.link;
+				existing.filmYear = candidate.filmYear ?? existing.filmYear;
+				existing.memberRating = candidate.memberRating ?? existing.memberRating;
+				existing.rating100 = candidate.rating100 ?? existing.rating100;
+				existing.posterUrl = candidate.posterUrl ?? existing.posterUrl;
+				if (candidate.reviewText) {
+					existing.reviewText = candidate.reviewText;
+				}
+			} else {
+				if (!existing.posterUrl && candidate.posterUrl) existing.posterUrl = candidate.posterUrl;
+				if (!existing.reviewText && candidate.reviewText) existing.reviewText = candidate.reviewText;
+				if (!existing.filmYear && candidate.filmYear) existing.filmYear = candidate.filmYear;
+				if (existing.memberRating === undefined && candidate.memberRating !== undefined) {
+					existing.memberRating = candidate.memberRating;
+					existing.rating100 = candidate.rating100;
+				}
+			}
+		}
+
+		return movieMap;
+	}
+
+	private async upsertMovieNote(movieEntry: MovieEntry): Promise<void> {
+		const fileName = sanitizeMovieFilename(movieEntry.filmTitle);
+		const filePath = normalizePath(`${this.settings.moviesPath}/${fileName}.md`);
+		let movieFile = this.app.vault.getFileByPath(filePath);
+		const today = moment().format('YYYY-MM-DD');
+		const existingFrontmatter = movieFile ? this.app.metadataCache.getFileCache(movieFile)?.frontmatter : undefined;
+		const needsMetadata = !movieFile
+			|| !existingFrontmatter
+			|| !hasValue(existingFrontmatter.genre)
+			|| !hasValue(existingFrontmatter.director)
+			|| !hasValue(existingFrontmatter.cast)
+			|| !hasValue(existingFrontmatter.plot)
+			|| !hasValue(existingFrontmatter.scoreLB);
+		const filmMetadata = needsMetadata ? await this.fetchFilmMetadata(movieEntry.link) : null;
+
+		if (!movieFile) {
+			movieFile = await this.app.vault.create(filePath, '---\n---\n');
+		}
+
+		await this.app.fileManager.processFrontMatter(movieFile, (frontmatter) => {
+			const categories = ensureStringArray(frontmatter.category);
+			if (!categories.includes('[[Movies]]')) categories.push('[[Movies]]');
+			frontmatter.category = categories.length ? categories : ['[[Movies]]'];
+
+			if (!hasValue(frontmatter.genre)) frontmatter.genre = toWikiLinks(filmMetadata?.genres ?? []);
+			if (!hasValue(frontmatter.director)) frontmatter.director = toWikiLinks(filmMetadata?.directors ?? []);
+			if (!hasValue(frontmatter.cast)) frontmatter.cast = toWikiLinks(filmMetadata?.cast ?? []);
+			if (!hasValue(frontmatter.plot)) frontmatter.plot = filmMetadata?.plot ?? '';
+
+			if (!hasValue(frontmatter.created)) frontmatter.created = today;
+			if (!hasValue(frontmatter.year) && filmMetadata?.year !== undefined) frontmatter.year = filmMetadata.year;
+			if (!hasValue(frontmatter.year) && movieEntry.filmYear !== undefined) frontmatter.year = movieEntry.filmYear;
+			if (!hasValue(frontmatter.cover) && filmMetadata?.cover) frontmatter.cover = filmMetadata.cover;
+			if (!hasValue(frontmatter.cover) && movieEntry.posterUrl) frontmatter.cover = movieEntry.posterUrl;
+			if (!hasValue(frontmatter.scoreLB) && filmMetadata?.scoreLB !== undefined) frontmatter.scoreLB = filmMetadata.scoreLB;
+			if (!hasValue(frontmatter.scoreLB) && movieEntry.memberRating !== undefined) frontmatter.scoreLB = movieEntry.memberRating;
+			const currentRating = Number(frontmatter.rating);
+			const shouldSetRating = !hasValue(frontmatter.rating) || Number.isNaN(currentRating) || currentRating === 0;
+			if (shouldSetRating && movieEntry.rating100 !== undefined) frontmatter.rating = movieEntry.rating100;
+			if (!hasValue(frontmatter.rating) && movieEntry.rating100 === undefined) frontmatter.rating = 0;
+
+			const currentLast = typeof frontmatter.last === 'string' ? frontmatter.last : '';
+			if (!currentLast || movieEntry.watchedDate > currentLast) frontmatter.last = movieEntry.watchedDate;
+
+			const tags = ensureStringArray(frontmatter.tags);
+			if (!tags.includes('movies')) tags.push('movies');
+			if (!tags.includes('review')) tags.push('review');
+			frontmatter.tags = tags;
+		});
+
+		if (movieEntry.reviewText && movieEntry.reviewText.trim().length > 0) {
+			await this.app.vault.process(movieFile, (data) => {
+				const { frontmatter, body } = splitFrontmatter(data);
+				if (body.trim().length > 0) return data;
+				const prefix = frontmatter.length ? `${frontmatter}\n` : '';
+				return `${prefix}${movieEntry.reviewText?.trim()}\n`;
+			});
+		}
+	}
+
+	private async ensureFolderExists(folderPath: string): Promise<void> {
+		const normalizedFolder = normalizePath(folderPath);
+		if (!normalizedFolder.length) return;
+		const existing = this.app.vault.getAbstractFileByPath(normalizedFolder);
+		if (existing) return;
+
+		const parts = normalizedFolder.split('/');
+		let currentPath = '';
+		for (const part of parts) {
+			currentPath = currentPath ? `${currentPath}/${part}` : part;
+			const existingPart = this.app.vault.getAbstractFileByPath(currentPath);
+			if (!existingPart) {
+				await this.app.vault.createFolder(currentPath);
+			}
+		}
 	}
 
 	async loadSettings() {
@@ -305,6 +700,29 @@ class LetterboxdSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
+			.setName('Sync movie notes')
+			.setDesc('Create or update one note per movie after each sync.')
+			.addToggle((component) => {
+				component.setValue(this.plugin.settings.syncMovieNotes);
+				component.onChange(async (value) => {
+					this.plugin.settings.syncMovieNotes = value;
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
+			.setName('Movies folder')
+			.setDesc('Folder where movie notes will be created/updated.')
+			.addText((component) => {
+				component.setPlaceholder('06 - Resources/Movies');
+				component.setValue(this.plugin.settings.moviesPath);
+				component.onChange(async (value) => {
+					this.plugin.settings.moviesPath = value.trim() || '06 - Resources/Movies';
+					await this.plugin.saveSettings();
+				});
+			});
+
+		new Setting(containerEl)
 			.setName('Sort by Date')
 			.setDesc('Select the order to list your diary entries.')
 			.addDropdown((component) => {
@@ -354,35 +772,29 @@ class LetterboxdSettingTab extends PluginSettingTab {
 					await this.plugin.saveSettings()
 				})
 			})
+			new Setting(containerEl)
+				.setName('Date Format')
+				.setDesc('Enter the Moment.js date format to display watched dates (e.g., YYYY-MM-DD)')
+			.addText((text) => {
+				text.setPlaceholder('YYYY-MM-DD');
+				text.setValue(this.plugin.settings.dateFormat);
 		
-			let datePreviewSpan: HTMLElement;
-
-const dateFormatSetting = new Setting(containerEl)
-	.setName('Date Format')
-	.setDesc('Enter the Moment.js date format to display watched dates (e.g., YYYY-MM-DD)');
-
-dateFormatSetting.addText((text) => {
-	text.setPlaceholder('YYYY-MM-DD');
-	text.setValue(this.plugin.settings.dateFormat);
-	text.onChange(async (value) => {
-		this.plugin.settings.dateFormat = value;
-		await this.plugin.saveSettings();
-		try {
-			datePreviewSpan.textContent = moment().format(value);
-		} catch (error) {
-			datePreviewSpan.textContent = 'Invalid format';
-		}
-	});
-});
-
-// Append the preview element to the info element (left column) so it appears below the description.
-datePreviewSpan = dateFormatSetting.infoEl.createEl('div', { cls: 'date-format-preview' });
-datePreviewSpan.style.fontSize = '0.8em';    // Smaller font size
-datePreviewSpan.style.marginTop = '4px';       // Small margin for spacing
-datePreviewSpan.style.whiteSpace = 'nowrap';   // Keep it on one single line
-datePreviewSpan.style.color = 'var(--text-accent)';  // Obsidian’s accent (purple) color
-datePreviewSpan.textContent = `This is how it will look: ${moment().format(this.plugin.settings.dateFormat)}`;
-
+				// Create a preview element right after the text input.
+				const previewEl = containerEl.createEl('div', { cls: 'date-format-preview', text: `This is how it will look: ${moment().format(this.plugin.settings.dateFormat)}` });
+		
+				// When the text input changes, update the preview.
+				text.onChange(async (value) => {
+					this.plugin.settings.dateFormat = value;
+					await this.plugin.saveSettings();
+					try {
+						// Update preview with current date in the given format.
+						previewEl.textContent = `This is how it will look: ${moment().format(value)}`;
+					} catch (error) {
+						previewEl.textContent = `This is how it will look: Invalid format`;
+					}
+					});
+				});
 			
+			
+		}
 	}
-}

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-	"id": "letterboxd-rss-sync",
-	"name": "Letterboxd Diary RSS Sync",
+	"id": "letterboxd-rss-sync-fork",
+	"name": "Letterboxd Diary RSS Sync Fork",
 	"version": "1.2.0",
 	"minAppVersion": "1.4.16",
 	"description": "Syncs your public Letterboxd diary.",


### PR DESCRIPTION
---

## PR Title: Add Date Format Selector Feature

### Description
This pull request introduces a new feature that allows users to select their preferred date format for syncing their Letterboxd diary entries to Obsidian. The date format selector provides flexibility and customization, enabling users to choose from various date formats such as `YYYY-MM-DD`, `MM-DD-YYYY`, or `DD-MM-YYYY`.

![CleanShot 2025-02-05 at 04 01 57@2x](https://github.com/user-attachments/assets/fd67cc0b-50d7-4788-aa76-b56c18b7e2d0)


### Changes
- Added a date format selector in the settings.
- Implemented functionality to apply the selected date format to all synced diary entries.

### Benefits
- **User Preference**: Users can now match the date format to their personal or regional preferences.
- **Consistency**: Ensures consistent date formatting across different entries and notes in Obsidian.
- **Flexibility**: Provides options for users who work with different date formats in various projects.

---

Feel free to review and make any adjustments as needed.